### PR TITLE
TWT-1809: Updated accounting email address 

### DIFF
--- a/general-information/frequently-asked-questions/costs-and-billing.md
+++ b/general-information/frequently-asked-questions/costs-and-billing.md
@@ -2,7 +2,7 @@
 
 ### From where can I download my invoices?
 
-You will receive monthly invoices by email to the specified invoice recipient. If you have any questions about your accounts, contact via email at [<mark style="color:blue;">account@cloud.ionos.com</mark>](mailto:account@cloud.ionos.com) or your IONOS Cloud account manager.
+You will receive monthly invoices by email to the specified invoice recipient. If you have any questions about your accounts, contact via email at [<mark style="color:blue;">accounting@billing.ionos.com</mark>](mailto:accounting@billing.ionos.com) or your IONOS Cloud account manager.
 
 ### Can I limit my costs?
 


### PR DESCRIPTION
On https://docs.ionos.com/faq/categories/costs-and-billing, changed the email address from _account@cloud.ionos.com_ in the first paragraph "From where can I download my invoices?" to the following: **accounting@billing.ionos.com**